### PR TITLE
Revert "Switched to the alpaca_py library"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ tqdm>=4.55.1
 yfinance==0.1.67
 openpyxl>=3.0.6
 slackclient>=2.9.4
-alpaca-py
+alpaca_trade_api
 pandas_market_calendars

--- a/src/trading_classes.py
+++ b/src/trading_classes.py
@@ -1,13 +1,13 @@
 import os
 import pandas as pd
 import yfinance as yf
-import alpaca_py as tradeapi
+import alpaca_trade_api as tradeapi
 import configparser
 import pytz
 import locale
 import pandas_market_calendars as mcal
 
-from alpaca_py.rest import APIError
+from alpaca_trade_api.rest import APIError
 from ta.volatility import BollingerBands
 from ta.momentum import RSIIndicator
 from ta.trend import sma_indicator


### PR DESCRIPTION
Fixes #1.

The API for `alpaca-py` looks quite different, imports look like `from alpaca.broker.…`, etc.